### PR TITLE
Cleanup, comments, and formatting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/tritonserver:23.03-py3
+FROM nvcr.io/nvidia/tritonserver:23.05-py3
 
 RUN mkdir /opt/tritonserver/caches/redis
 COPY ./build/install/caches/redis/libtritoncache_redis.so /opt/tritonserver/caches/redis

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 This repo contains an example
 [cache](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritoncache.h)
-for caching data with Redis.
+for caching data with [Redis](https://redis.io/).
 
 Ask questions or report problems in the main Triton [issues
 page](https://github.com/triton-inference-server/server/issues).

--- a/src/redis_cache.h
+++ b/src/redis_cache.h
@@ -44,7 +44,7 @@ struct CacheEntry {
   std::unordered_map<std::string, std::string> items;
 };
 
-// This is the number of fields that are created to each buffer to marshall
+// This is the number of fields that are created to each buffer to marshal
 // the buffer back to Triton
 constexpr uint32_t FIELDS_PER_BUFFER = 4;
 


### PR DESCRIPTION
Just cleaning up some error messages, adding spaces, adding a couple comments around Triton behavior for readers, and applying formatting.