### PR TITLE
Catch generic base exception, move handleError out to helper function

### DIFF
--- a/src/redis_cache.cc
+++ b/src/redis_cache.cc
@@ -95,7 +95,7 @@ handleError(
     const std::string& cause)
 {
   std::ostringstream msg;
-  msg << message << key << " from cache. " << cause;
+  msg << message << key << ". " << cause;
   return TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, msg.str().c_str());
 }
 


### PR DESCRIPTION
Ran into some failures to insert in CI on the generic `catch (...)` case, I don't know why. Adding base exception case to try to get the `e.what()` when it happens.

Also moved `handleError` out to a helper since it's doing the same thing in both methods.

---

@slorello89 @Spartee do you have a common practice for writing Redis server logs to a local file while in background / `daemonized` mode, so I can see if Redis server reported any errors/issues during the test?
- edit: Added `redis.conf` with local `logfile` to CI test: https://github.com/triton-inference-server/server/pull/5945