### PR TITLE
Auto-formatting

### DIFF
--- a/src/redis_cache.cc
+++ b/src/redis_cache.cc
@@ -24,10 +24,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "redis_cache.h"
+
 #include <sstream>
 
 #include "rapidjson/document.h"
-#include "redis_cache.h"
 #include "triton/common/logging.h"
 #include "triton/core/tritoncache.h"
 

--- a/src/redis_cache.h
+++ b/src/redis_cache.h
@@ -26,14 +26,15 @@
 
 #pragma once
 
+#include <sw/redis++/connection.h>
+#include <sw/redis++/redis++.h>
+
 #include <iostream>
 #include <list>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
-#include <sw/redis++/connection.h>
-#include <sw/redis++/redis++.h>
 #include "triton/core/tritoncache.h"
 #include "triton/core/tritonserver.h"
 


### PR DESCRIPTION
With the [upgrade to clang-format-15](https://github.com/triton-inference-server/common/pull/94) in our formatter, we are running the formatter on all Triton repos. If you would like to use the formatting tool in this repo, feel free to approve/merge this PR.

CC: @rmccorm4 