### PR TITLE
Add GitHub action to format and lint code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,7 @@
 BasedOnStyle: Google
 
 IndentWidth: 2
+ColumnLimit: 80
 ContinuationIndentWidth: 4
 UseTab: Never
 MaxEmptyLinesToKeep: 2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,41 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
+

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,8 +28,6 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   pre-commit:
@@ -38,4 +36,3 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.0
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,8 @@ repos:
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0
   hooks:
-  - id: isort
-    additional_dependencies: [toml]
+      - id: isort
+        additional_dependencies: [toml]
 - repo: https://github.com/psf/black
   rev: 23.1.0
   hooks:
@@ -59,16 +59,16 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
-    - id: check-case-conflict
-    - id: check-executables-have-shebangs
-    - id: check-merge-conflict
-    - id: check-json
-    - id: check-toml
-    - id: check-yaml
-    - id: check-shebang-scripts-are-executable
-    - id: end-of-file-fixer
-      types_or: [c, c++, cuda, proto, textproto, java, python]
-    - id: mixed-line-ending
-    - id: requirements-txt-fixer
-    - id: trailing-whitespace
+        - id: check-case-conflict
+        - id: check-executables-have-shebangs
+        - id: check-merge-conflict
+        - id: check-json
+        - id: check-toml
+        - id: check-yaml
+        - id: check-shebang-scripts-are-executable
+        - id: end-of-file-fixer
+          types_or: [c, c++, cuda, proto, textproto, java, python]
+        - id: mixed-line-ending
+        - id: requirements-txt-fixer
+        - id: trailing-whitespace
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,74 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+repos:
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.12.0
+  hooks:
+  - id: isort
+    additional_dependencies: [toml]
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+      - id: black
+        types_or: [python, cython]
+- repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4
+  hooks:
+      - id: flake8
+        args: [--max-line-length=88, --select=C,E,F,W,B,B950, --extend-ignore = E203,E501]
+        types_or: [python, cython]
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v16.0.5
+  hooks:
+      - id: clang-format
+        types_or: [c, c++, cuda, proto, textproto, java]
+        args: ["-fallback-style=none", "-style=file", "-i"]
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
+        args: ["--toml", "pyproject.toml"]
+        exclude: (?x)^(.*stemmer.*|.*stop_words.*|^CHANGELOG.md$)
+# More details about these pre-commit hooks here:
+# https://pre-commit.com/hooks.html
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-case-conflict
+    - id: check-executables-have-shebangs
+    - id: check-merge-conflict
+    - id: check-json
+    - id: check-toml
+    - id: check-yaml
+    - id: check-shebang-scripts-are-executable
+    - id: end-of-file-fixer
+      types_or: [c, c++, cuda, proto, textproto, java, python]
+    - id: mixed-line-ending
+    - id: requirements-txt-fixer
+    - id: trailing-whitespace
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,16 +59,16 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
-        - id: check-case-conflict
-        - id: check-executables-have-shebangs
-        - id: check-merge-conflict
-        - id: check-json
-        - id: check-toml
-        - id: check-yaml
-        - id: check-shebang-scripts-are-executable
-        - id: end-of-file-fixer
-          types_or: [c, c++, cuda, proto, textproto, java, python]
-        - id: mixed-line-ending
-        - id: requirements-txt-fixer
-        - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: check-shebang-scripts-are-executable
+      - id: end-of-file-fixer
+        types_or: [c, c++, cuda, proto, textproto, java, python]
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,47 +28,46 @@ repos:
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0
   hooks:
-      - id: isort
-        additional_dependencies: [toml]
+  - id: isort
+    additional_dependencies: [toml]
 - repo: https://github.com/psf/black
   rev: 23.1.0
   hooks:
-      - id: black
-        types_or: [python, cython]
+  - id: black
+    types_or: [python, cython]
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:
-      - id: flake8
-        args: [--max-line-length=88, --select=C,E,F,W,B,B950, --extend-ignore = E203,E501]
-        types_or: [python, cython]
+  - id: flake8
+    args: [--max-line-length=88, --select=C,E,F,W,B,B950, --extend-ignore = E203,E501]
+    types_or: [python, cython]
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v16.0.5
   hooks:
-      - id: clang-format
-        types_or: [c, c++, cuda, proto, textproto, java]
-        args: ["-fallback-style=none", "-style=file", "-i"]
+  - id: clang-format
+    types_or: [c, c++, cuda, proto, textproto, java]
+    args: ["-fallback-style=none", "-style=file", "-i"]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.4
   hooks:
-      - id: codespell
-        additional_dependencies: [tomli]
-        args: ["--toml", "pyproject.toml"]
-        exclude: (?x)^(.*stemmer.*|.*stop_words.*|^CHANGELOG.md$)
+  - id: codespell
+    additional_dependencies: [tomli]
+    args: ["--toml", "pyproject.toml"]
+    exclude: (?x)^(.*stemmer.*|.*stop_words.*|^CHANGELOG.md$)
 # More details about these pre-commit hooks here:
 # https://pre-commit.com/hooks.html
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
-      - id: check-case-conflict
-      - id: check-executables-have-shebangs
-      - id: check-merge-conflict
-      - id: check-json
-      - id: check-toml
-      - id: check-yaml
-      - id: check-shebang-scripts-are-executable
-      - id: end-of-file-fixer
-        types_or: [c, c++, cuda, proto, textproto, java, python]
-      - id: mixed-line-ending
-      - id: requirements-txt-fixer
-      - id: trailing-whitespace
-
+  - id: check-case-conflict
+  - id: check-executables-have-shebangs
+  - id: check-merge-conflict
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml
+  - id: check-shebang-scripts-are-executable
+  - id: end-of-file-fixer
+    types_or: [c, c++, cuda, proto, textproto, java, python]
+  - id: mixed-line-ending
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 #
 # Dependencies
 #
-# FetchContent's composibility isn't very good. We must include the
+# FetchContent's composability isn't very good. We must include the
 # transitive closure of all repos so that we can override the tag.
 #
 include(FetchContent)

--- a/docker-compose-gpu.yml
+++ b/docker-compose-gpu.yml
@@ -15,7 +15,7 @@ services:
                 capabilities: [gpu]
     links:
       -   triton-redis
-    build: 
+    build:
       context: .
     command: tritonserver --cache-config redis,host=triton-redis --cache-config redis,port=6379 --model-repository=/models
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   triton-server:
     links:
       -   triton-redis
-    build: 
+    build:
       context: .
     command: tritonserver --cache-config redis,host=triton-redis --cache-config redis,port=6379 --model-repository=/models
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[tool.codespell]
+# note: pre-commit passes explicit lists of files here, which this skip file list doesn't override -
+# this is only to allow you to run codespell interactively
+skip = "./.git,./.github"
+# ignore short words, and typename parameters like OffsetT
+ignore-regex = "\\b(.{1,4}|[A-Z]\\w*T)\\b"
+# use the 'clear' dictionary for unambiguous spelling mistakes
+builtin = "clear"
+# disable warnings about binary files and wrong encoding
+quiet-level = 3
+
+[tool.isort]
+profile = "black"
+use_parentheses = true
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+ensure_newline_before_comments = true
+line_length = 88
+balanced_wrapping = true
+indent = "    "
+skip = ["build"]
+


### PR DESCRIPTION
This pull request adds pre-commit hooks. It also includes running the pre-commit hooks on these files, plus making fixes based on them (e.g. making sure all .py and .sh executables are set to be executable and have shebangs, spelling corrections, etc.).

This pull request adds pre-commit hooks to run the following:

Black for formatting Python
Flake8 for linting Python for conformance to PEP8, PyFlakes, and circular complexity (max-line-length set to match Black's 88 default/recommended character limit; this and other settings from Black's documentation [here](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length) to avoid enforcement of limit when unnecessary).
isort for deterministically sorting and organizing Python imports
Clang for formatting C++, C, Java, TextProto, Proto, and CUDA
Codespell for finding common spelling mistakes
In addition, this adds these native pre-commit hooks, details [here](https://pre-commit.com/hooks.html):

check-case-conflict
check-executables-have-shebangs
check-merge-conflict
check-json
check-toml
check-yaml
check-shebang-scripts-are-executable
end-of-file-fixer
mixed-line-ending
requirements-txt-fixer
trailing-whitespace
To run these locally, you can go into the repo and run pip install pre-commit and pre-commit install. After that has been done once, you just need to run pre-commit run --all-files any time you want to apply them. Once installed, it should run automatically on commit for files included in a commit. To correct spelling errors found by codespell when possible, you can install codespell (pip install codespell and potentially pip install --upgrade codespell to use the toml file in the directory) and call codespell -w <path>.

This pull request also adds a GitHub action so that these are run for every pull request and push to main. The core changes are in pre-commit.yml, pre-commit-config.yaml, and pyproject.toml. The rest of the changes are the effect of applying the action to the current repo.