### PR TITLE
Simplify PING call, expect default response

### DIFF
--- a/src/redis_cache.cc
+++ b/src/redis_cache.cc
@@ -41,7 +41,8 @@ init_client(
 {
   std::unique_ptr<sw::redis::Redis> redis =
       std::make_unique<sw::redis::Redis>(connectionOptions, poolOptions);
-  if (redis->ping() != "PONG") {
+  const auto msg = "PONG";
+  if (redis->ping() != msg) {
     throw std::runtime_error("Failed to ping Redis server.");
   }
 

--- a/src/redis_cache.cc
+++ b/src/redis_cache.cc
@@ -41,8 +41,7 @@ init_client(
 {
   std::unique_ptr<sw::redis::Redis> redis =
       std::make_unique<sw::redis::Redis>(connectionOptions, poolOptions);
-  const auto msg = "Triton RedisCache client connected";
-  if (redis->ping(msg) != msg) {
+  if (redis->ping() != "PONG") {
     throw std::runtime_error("Failed to ping Redis server.");
   }
 


### PR DESCRIPTION
This simplifies PING call during the initialisation, to pass no parameters and expect the default response.

## Why?
My motivation for this change is to enable support of Redis under Envoy proxy:
- Envoy doesn't support PING with parameters and Triton fails to initialise the cache (`error: creating server: Internal - Failed to initialise RedisCache: Failed to ping Redis server.`)
- Standard Redis `PING` response without parameter is `PONG` - that's how Envoy Redis also behaves.
- This increases cache compatibility with a very minimal change to initialisation.

## Testing
I performed some manual tests to verify this change behaves as expected:
- built binary on Mac inside Docker container
- loaded into Triton Server as a custom cache
- tested SigLIP2 model calls on locally running regular Redis container
- tested SigLIP2 model calls on Envoy Redis
- In both cases verified that the cache is being used